### PR TITLE
feat: create, delete, modify hint

### DIFF
--- a/app/components/HintAddForm/HintAddForm.tsx
+++ b/app/components/HintAddForm/HintAddForm.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { useForm } from "react-hook-form";
+import React, { useEffect } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { usePostHint } from "@/mutations/postHint";
 import HintAddFormView from "./HintAddFormView";
 import { useIsOpenAddAccordionWrite } from "../atoms/hints.atom";
 
 interface FormValues {
-  progress: string;
+  progress: number;
   hintCode: string;
   contents: string;
   answer: string;
@@ -13,9 +14,23 @@ interface FormValues {
 function HintAddForm() {
   const { register, handleSubmit } = useForm<FormValues>();
   const setAdding = useIsOpenAddAccordionWrite();
+  const { mutateAsync: postHint, isSuccess } = usePostHint();
 
-  const onSubmit = () => {
-    console.log("run");
+  useEffect(() => {
+    if (isSuccess) {
+      setAdding(false);
+    }
+  }, [isSuccess, setAdding]);
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => {
+    const { progress, hintCode, contents, answer } = data;
+    if (progress && hintCode && contents && answer) {
+      postHint({ progress: Number(progress), hintCode, contents, answer });
+    } else {
+      // TODO: add error message
+      // eslint-disable-next-line no-console
+      console.error("please check code");
+    }
   };
 
   const formProps = {
@@ -28,22 +43,22 @@ function HintAddForm() {
   const progressInputProps = {
     placeholder: "진행률",
     type: "number",
-    ...register("progress", { required: true }),
+    register: { ...register("progress") },
   };
 
   const hintCodeInputProps = {
     placeholder: "힌트코드",
-    ...register("hintCode", { required: true }),
+    register: { ...register("hintCode") },
   };
   const contentsInputProps = {
     placeholder: "힌트내용",
     multiline: true,
-    ...register("contents", { required: true }),
+    register: { ...register("contents") },
   };
   const answerInputProps = {
     placeholder: "정답",
     multiline: true,
-    ...register("answer", { required: true }),
+    register: { ...register("answer") },
   };
 
   const deleteButtonProps = {

--- a/app/components/HintAddForm/HintAddForm.tsx
+++ b/app/components/HintAddForm/HintAddForm.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import HintAddFormView from "./HintAddFormView";
+import { useIsOpenAddAccordionWrite } from "../atoms/hints.atom";
+
+interface FormValues {
+  progress: string;
+  hintCode: string;
+  contents: string;
+  answer: string;
+}
+
+function HintAddForm() {
+  const { register, handleSubmit } = useForm<FormValues>();
+  const setAdding = useIsOpenAddAccordionWrite();
+
+  const onSubmit = () => {
+    console.log("run");
+  };
+
+  const formProps = {
+    component: "form",
+    noValidate: true,
+    autoComplete: "off",
+    onSubmit: handleSubmit(onSubmit),
+  };
+
+  const progressInputProps = {
+    placeholder: "진행률",
+    type: "number",
+    ...register("progress", { required: true }),
+  };
+
+  const hintCodeInputProps = {
+    placeholder: "힌트코드",
+    ...register("hintCode", { required: true }),
+  };
+  const contentsInputProps = {
+    placeholder: "힌트내용",
+    multiline: true,
+    ...register("contents", { required: true }),
+  };
+  const answerInputProps = {
+    placeholder: "정답",
+    multiline: true,
+    ...register("answer", { required: true }),
+  };
+
+  const deleteButtonProps = {
+    onClick: () => setAdding(false),
+  };
+
+  const makeHintButtonProps = {
+    type: "submit",
+    variant: "contained",
+  };
+
+  const hintAddFormProps = {
+    answerInputProps,
+    contentsInputProps,
+    progressInputProps,
+    hintCodeInputProps,
+    formProps,
+    deleteButtonProps,
+    makeHintButtonProps,
+  };
+
+  return <HintAddFormView {...hintAddFormProps} />;
+}
+
+export default HintAddForm;

--- a/app/components/HintAddForm/HintAddFormView.styled.ts
+++ b/app/components/HintAddForm/HintAddFormView.styled.ts
@@ -1,0 +1,63 @@
+import { Stack } from "@mui/material";
+import { styled } from "styled-components";
+
+export const SummaryStack = styled(Stack)`
+  width: 100%;
+  align-items: center;
+`;
+
+export const CodeProgressWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  width: 360px;
+  height: 30px;
+`;
+
+export const IconText = styled.div`
+  display: flex;
+  width: 168px;
+  justify-content: baseline;
+  align-items: center;
+  color: #6750a4;
+
+  svg {
+    margin-right: 15px;
+    fill: #6750a4;
+  }
+`;
+
+export const SummaryText = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 600px;
+  align-items: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const DetailIconText = styled.div`
+  display: flex;
+  flex: 30px auto;
+  width: 100%;
+  margin: 15px 0;
+
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+
+  svg {
+    display: block;
+    margin-right: 25px;
+    fill: #aea9b1;
+  }
+
+  & + & {
+    margin-top: 30px;
+  }
+`;
+
+export const ButtonsStack = styled(Stack)`
+  justify-content: end;
+  align-items: center;
+`;

--- a/app/components/HintAddForm/HintAddFormView.tsx
+++ b/app/components/HintAddForm/HintAddFormView.tsx
@@ -8,7 +8,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { ChatBubbleOutline, Code, Done, Water } from "@mui/icons-material";
 
 import * as S from "./HintAddFormView.styled";
@@ -44,11 +43,7 @@ function HintAddFormView(props: Props) {
   return (
     <Box {...formProps}>
       <Accordion key="add" expanded>
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon color="inherit" />}
-          aria-controls="panel1a-content"
-          id="panel1a-header"
-        >
+        <AccordionSummary aria-controls="panel1a-content" id="panel1a-header">
           <Typography color="inherit">
             <S.SummaryStack direction="row">
               <Stack direction="row">

--- a/app/components/HintAddForm/HintAddFormView.tsx
+++ b/app/components/HintAddForm/HintAddFormView.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { ChatBubbleOutline, Code, Done, Water } from "@mui/icons-material";
+
+import * as S from "./HintAddFormView.styled";
+import { ActiveInput } from "../common";
+import { ActiveInputProps } from "../common/ActiveInput/ActiveInput";
+
+interface Props {
+  progressInputProps: ActiveInputProps;
+  hintCodeInputProps: ActiveInputProps;
+  contentsInputProps: ActiveInputProps;
+  answerInputProps: ActiveInputProps;
+  deleteButtonProps: { onClick: () => void };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formProps: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  makeHintButtonProps: Record<string, any>;
+}
+
+const DELETE = "삭제하기";
+const MAKE_HINT = "힌트 만들기";
+
+function HintAddFormView(props: Props) {
+  const {
+    progressInputProps,
+    hintCodeInputProps,
+    contentsInputProps,
+    answerInputProps,
+    deleteButtonProps,
+    makeHintButtonProps,
+    formProps,
+  } = props;
+
+  return (
+    <Box {...formProps}>
+      <Accordion key="add" expanded>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon color="inherit" />}
+          aria-controls="panel1a-content"
+          id="panel1a-header"
+        >
+          <Typography color="inherit">
+            <S.SummaryStack direction="row">
+              <Stack direction="row">
+                <S.CodeProgressWrapper>
+                  <S.IconText>
+                    <Water />
+                    <ActiveInput {...progressInputProps} />
+                  </S.IconText>
+                  <S.IconText>
+                    <Code />
+                    <ActiveInput {...hintCodeInputProps} />
+                  </S.IconText>
+                </S.CodeProgressWrapper>
+              </Stack>
+            </S.SummaryStack>
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography color="inherit">
+            <S.DetailIconText>
+              <ChatBubbleOutline />
+              <ActiveInput {...contentsInputProps} />
+            </S.DetailIconText>
+            <S.DetailIconText>
+              <Done />
+              <ActiveInput {...answerInputProps} />
+            </S.DetailIconText>
+          </Typography>
+          <S.ButtonsStack direction="row" spacing={3}>
+            <Button {...deleteButtonProps}>{DELETE}</Button>
+            <Button {...makeHintButtonProps}>{MAKE_HINT}</Button>
+          </S.ButtonsStack>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+}
+
+export default HintAddFormView;

--- a/app/components/HintAddForm/index.ts
+++ b/app/components/HintAddForm/index.ts
@@ -1,0 +1,2 @@
+export { default as HintAddForm } from "./HintAddForm";
+export { default as HintAddFormView } from "./HintAddFormView";

--- a/app/components/HintManageList/HintManageListView.tsx
+++ b/app/components/HintManageList/HintManageListView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Stack } from "@mui/material";
 import { Hints } from "@/queries/getHintList";
 import { HintManageListItem } from "../HintManageListItem";
+import { HintAddForm } from "../HintAddForm";
 
 interface Props {
   hints: Hints;
@@ -14,7 +15,7 @@ function HintManageListView(props: Props) {
   return (
     <Stack spacing={3}>
       <Stack direction="column">
-        {adding && <div>힌트 추가 화면</div>}
+        {adding && <HintAddForm />}
         {hints.map(({ id, hintCode, contents, answer, progress }) => (
           <HintManageListItem
             id={id}

--- a/app/components/HintManageListItem/HintManageListItem.tsx
+++ b/app/components/HintManageListItem/HintManageListItem.tsx
@@ -1,6 +1,12 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import { usePutHint } from "@/mutations/putHint";
+
 import HintManageListItemView from "./HintManageListItemView";
 import { DeleteHintDialog } from "../DeleteHintDialog";
+
+import { useSelectedThemeValue } from "../atoms/selectedTheme.atom";
 
 type Props = {
   id: number;
@@ -10,25 +16,113 @@ type Props = {
   progress: number;
 };
 
+interface FormValues {
+  progress: number;
+  hintCode: string;
+  contents: string;
+  answer: string;
+}
+
 function HintManageListItem(props: Props) {
   const { id, hintCode, contents, answer, progress } = props;
+
+  const { mutateAsync: putHint } = usePutHint();
+
   const [open, setOpen] = useState<boolean>(false);
-  // const { id: themeId = 1 } = useSelectedThemeValue();
-  const themeId = 1;
+  const [submitDisable, setSubmitDisable] = useState<boolean>(true);
+  const { id: themeId = 1 } = useSelectedThemeValue();
 
   const onDelete = () => {
     setOpen(true);
   };
   const onSave = () => {};
 
+  const { register, handleSubmit, setValue, watch } = useForm<FormValues>();
+
+  useEffect(() => {
+    const previousValues: FormValues = { hintCode, contents, answer, progress };
+    const names = Object.keys(previousValues) as (keyof FormValues)[];
+
+    names.forEach((name) => {
+      const value = previousValues[name];
+      if (value) {
+        setValue(name, value);
+      }
+    });
+  }, [answer, contents, hintCode, progress, setValue]);
+
+  useEffect(() => {
+    const subscription = watch((value) => {
+      const {
+        progress: inputProgress = "",
+        hintCode: inputHintCode = "",
+        contents: inputContents = "",
+        answer: inputAnswer = "",
+      } = value;
+      if (
+        progress !== inputProgress ||
+        hintCode !== inputHintCode ||
+        contents !== inputContents ||
+        answer !== inputAnswer
+      ) {
+        setSubmitDisable(false);
+      } else {
+        setSubmitDisable(true);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [answer, contents, hintCode, progress, watch]);
+
+  const onSubmit: SubmitHandler<FormValues> = (data) => {
+    putHint({ ...data, id });
+  };
+
+  const formProps = {
+    key: id,
+    component: "form",
+    noValidate: true,
+    autoComplete: "off",
+    onSubmit: handleSubmit(onSubmit),
+  };
+
+  const progressInputProps = {
+    placeholder: progress || "진행률",
+    type: "number",
+    register: { ...register("progress") },
+  };
+
+  const hintCodeInputProps = {
+    placeholder: hintCode || "힌트코드",
+    register: { ...register("hintCode") },
+  };
+  const contentsInputProps = {
+    placeholder: contents || "힌트내용",
+    multiline: true,
+    register: { ...register("contents") },
+  };
+  const answerInputProps = {
+    placeholder: answer || "정답",
+    multiline: true,
+    register: { ...register("answer") },
+  };
+
+  const saveButtonProps = {
+    variant: "contained",
+    disabled: submitDisable,
+    onClick: onSave,
+    type: "submit",
+  };
+
   const HintManageListItemProps = {
     id,
-    hintCode,
     contents,
-    answer,
-    progress,
     onDelete,
-    onSave,
+    progressInputProps,
+    contentsInputProps,
+    hintCodeInputProps,
+    answerInputProps,
+    formProps,
+    saveButtonProps,
   };
 
   return (

--- a/app/components/HintManageListItem/HintManageListItemView.tsx
+++ b/app/components/HintManageListItem/HintManageListItemView.tsx
@@ -1,76 +1,95 @@
-import { ChatBubbleOutline, Code, Done, Water } from "@mui/icons-material";
+import React from "react";
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Box,
   Button,
   Stack,
   Typography,
 } from "@mui/material";
-import React from "react";
+import { ChatBubbleOutline, Code, Done, Water } from "@mui/icons-material";
+
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ActiveInput, {
+  ActiveInputProps,
+} from "../common/ActiveInput/ActiveInput";
+
 import * as S from "./HintManageListItemView.styled";
 
 type Props = {
   id: number;
-  hintCode: string;
   contents: string;
-  answer: string;
-  progress: number;
   onDelete: () => void;
-  onSave: () => void;
+  progressInputProps: ActiveInputProps;
+  hintCodeInputProps: ActiveInputProps;
+  contentsInputProps: ActiveInputProps;
+  answerInputProps: ActiveInputProps;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formProps: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  saveButtonProps: Record<string, any>;
 };
 
 const DELETE = "삭제하기";
 const SAVE_MODIFIED_DATA = "변경사항 저장";
 
 function HintManageListItemView(props: Props) {
-  const { id, hintCode, contents, answer, progress, onDelete, onSave } = props;
+  const {
+    contents,
+    onDelete,
+    progressInputProps,
+    hintCodeInputProps,
+    contentsInputProps,
+    answerInputProps,
+    formProps,
+    saveButtonProps,
+  } = props;
 
   return (
-    <Accordion key={id}>
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon color="inherit" />}
-        aria-controls="panel1a-content"
-        id="panel1a-header"
-      >
-        <Typography color="inherit">
-          <S.SummaryStack direction="row">
-            <Stack direction="row">
-              <S.CodeProgressWrapper>
-                <S.IconText>
-                  <Water />
-                  {progress}
-                </S.IconText>
-                <S.IconText>
-                  <Code />
-                  {hintCode}
-                </S.IconText>
-              </S.CodeProgressWrapper>
-              <S.SummaryText>{contents}</S.SummaryText>
-            </Stack>
-          </S.SummaryStack>
-        </Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <Typography color="inherit">
-          <S.DetailIconText>
-            <ChatBubbleOutline />
-            {contents}
-          </S.DetailIconText>
-          <S.DetailIconText>
-            <Done />
-            {answer}
-          </S.DetailIconText>
-        </Typography>
-        <S.ButtonsStack direction="row" spacing={3}>
-          <Button onClick={onDelete}>{DELETE}</Button>
-          <Button variant="contained" disabled onClick={onSave}>
-            {SAVE_MODIFIED_DATA}
-          </Button>
-        </S.ButtonsStack>
-      </AccordionDetails>
-    </Accordion>
+    <Box {...formProps}>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon color="inherit" />}
+          aria-controls="panel1a-content"
+          id="panel1a-header"
+        >
+          <Typography color="inherit">
+            <S.SummaryStack direction="row">
+              <Stack direction="row">
+                <S.CodeProgressWrapper>
+                  <S.IconText>
+                    <Water />
+                    <ActiveInput {...progressInputProps} />
+                  </S.IconText>
+                  <S.IconText>
+                    <Code />
+                    <ActiveInput {...hintCodeInputProps} />
+                  </S.IconText>
+                </S.CodeProgressWrapper>
+                <S.SummaryText>{contents}</S.SummaryText>
+              </Stack>
+            </S.SummaryStack>
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Typography color="inherit">
+            <S.DetailIconText>
+              <ChatBubbleOutline />
+              <ActiveInput {...contentsInputProps} />
+            </S.DetailIconText>
+            <S.DetailIconText>
+              <Done />
+              <ActiveInput {...answerInputProps} />
+            </S.DetailIconText>
+          </Typography>
+          <S.ButtonsStack direction="row" spacing={3}>
+            <Button onClick={onDelete}>{DELETE}</Button>
+            <Button {...saveButtonProps}>{SAVE_MODIFIED_DATA}</Button>
+          </S.ButtonsStack>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
   );
 }
 

--- a/app/components/common/ActiveInput/ActiveInput.styled.ts
+++ b/app/components/common/ActiveInput/ActiveInput.styled.ts
@@ -2,15 +2,15 @@ import { TextField as MuiTextField } from "@mui/material";
 import { styled } from "styled-components";
 
 interface CommonProps {
-  active: boolean;
+  inputActive: boolean;
 }
 
 export const TextField = styled(MuiTextField)<CommonProps>`
-  display: ${({ active }) => (active ? "block" : "none")};
+  display: ${({ inputActive }) => (inputActive ? "block" : "none")};
 `;
 
 export const FormText = styled.span<CommonProps>`
-  display: ${({ active }) => (active ? "none" : "block")};
+  display: ${({ inputActive }) => (inputActive ? "none" : "block")};
   width: 100%;
   white-space: pre;
 `;

--- a/app/components/common/ActiveInput/ActiveInput.styled.ts
+++ b/app/components/common/ActiveInput/ActiveInput.styled.ts
@@ -1,14 +1,16 @@
-import { Input as MuiInput } from "@mui/material";
+import { TextField as MuiTextField } from "@mui/material";
 import { styled } from "styled-components";
 
 interface CommonProps {
   active: boolean;
 }
 
-export const Input = styled(MuiInput)<CommonProps>`
+export const TextField = styled(MuiTextField)<CommonProps>`
   display: ${({ active }) => (active ? "block" : "none")};
 `;
 
 export const FormText = styled.span<CommonProps>`
   display: ${({ active }) => (active ? "none" : "block")};
+  width: 100%;
+  white-space: pre;
 `;

--- a/app/components/common/ActiveInput/ActiveInput.styled.ts
+++ b/app/components/common/ActiveInput/ActiveInput.styled.ts
@@ -1,0 +1,14 @@
+import { Input as MuiInput } from "@mui/material";
+import { styled } from "styled-components";
+
+interface CommonProps {
+  active: boolean;
+}
+
+export const Input = styled(MuiInput)<CommonProps>`
+  display: ${({ active }) => (active ? "block" : "none")};
+`;
+
+export const FormText = styled.span<CommonProps>`
+  display: ${({ active }) => (active ? "none" : "block")};
+`;

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -1,17 +1,22 @@
 import React, { useState } from "react";
-import { Input } from "@mui/material";
+import { UseFormRegisterReturn } from "react-hook-form";
+import * as S from "./ActiveInput.styled";
 
-interface Props {
+interface Props extends UseFormRegisterReturn {
   // eslint-disable-next-line react/require-default-props
   type?: string;
   // eslint-disable-next-line react/require-default-props
   placeholder?: string;
-  // eslint-disable-next-line react/require-default-props
-  value: string;
-  onChange: () => void;
 }
 function ActiveInput(props: Props) {
-  const { type = "text", placeholder = "", value = "", onChange } = props;
+  const {
+    type = "text",
+    placeholder = "",
+    onChange,
+    onBlur: formHookOnBlur,
+    ref,
+    name,
+  } = props;
 
   const [active, setActive] = useState<boolean>(false);
 
@@ -19,19 +24,29 @@ function ActiveInput(props: Props) {
     setActive(!active);
   };
 
-  if (active) {
-    return (
-      <Input
+  const onBlur = (
+    e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>
+  ) => {
+    switchActive();
+    formHookOnBlur(e);
+  };
+
+  return (
+    <>
+      <S.Input
         type={type}
-        value={value}
         placeholder={placeholder}
         onChange={onChange}
-        onBlur={switchActive}
+        onBlur={onBlur}
+        ref={ref}
+        name={name}
+        active={active}
       />
-    );
-  }
-  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-  return <span onClick={switchActive}>{value || placeholder}</span>;
+      <S.FormText onClick={switchActive} active={active}>
+        {placeholder}
+      </S.FormText>
+    </>
+  );
 }
 
 export default ActiveInput;

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -2,23 +2,21 @@ import React, { useState } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import * as S from "./ActiveInput.styled";
 
-export interface ActiveInputProps extends UseFormRegisterReturn {
+export interface ActiveInputProps {
   // eslint-disable-next-line react/require-default-props
   type?: string;
   // eslint-disable-next-line react/require-default-props
   placeholder?: string;
   // eslint-disable-next-line react/require-default-props, react/no-unused-prop-types
   multiline?: boolean;
+  register: UseFormRegisterReturn;
 }
 function ActiveInput(props: ActiveInputProps) {
   const {
     multiline = false,
     type = "text",
     placeholder = "",
-    onChange: formHookOnChange,
-    onBlur: formHookOnBlur,
-    ref,
-    name,
+    register,
   } = props;
 
   const [inputActive, setInputActive] = useState<boolean>(false);
@@ -32,25 +30,24 @@ function ActiveInput(props: ActiveInputProps) {
     e: React.FocusEvent<HTMLTextAreaElement | HTMLInputElement, Element>
   ) => {
     switchActive();
-    formHookOnBlur(e);
+    register.onBlur(e);
   };
 
   const onChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
     setDisplayName(e.target.value);
-    formHookOnChange(e);
+    register.onChange(e);
   };
 
   return (
     <>
       <S.TextField
+        {...register}
         type={type}
         placeholder={placeholder}
         onChange={onChange}
         onBlur={onBlur}
-        ref={ref}
-        name={name}
         inputActive={inputActive}
         multiline={multiline}
         variant="standard"

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -21,11 +21,11 @@ function ActiveInput(props: ActiveInputProps) {
     name,
   } = props;
 
-  const [active, setActive] = useState<boolean>(false);
+  const [inputActive, setInputActive] = useState<boolean>(false);
   const [displayName, setDisplayName] = useState<string>("");
 
   const switchActive = () => {
-    setActive(!active);
+    setInputActive(!inputActive);
   };
 
   const onBlur = (
@@ -51,12 +51,12 @@ function ActiveInput(props: ActiveInputProps) {
         onBlur={onBlur}
         ref={ref}
         name={name}
-        active={active}
+        inputActive={inputActive}
         multiline={multiline}
         variant="standard"
         fullWidth
       />
-      <S.FormText onClick={switchActive} active={active}>
+      <S.FormText onClick={switchActive} inputActive={inputActive}>
         {displayName || placeholder}
       </S.FormText>
     </>

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -1,17 +1,37 @@
-import React from "react";
+import React, { useState } from "react";
 import { Input } from "@mui/material";
 
 interface Props {
-  type: string | undefined;
-  active: boolean;
+  // eslint-disable-next-line react/require-default-props
+  type?: string;
+  // eslint-disable-next-line react/require-default-props
+  placeholder?: string;
+  // eslint-disable-next-line react/require-default-props
   value: string;
   onChange: () => void;
 }
-function ActiveInput({ type = "text", active, value, onChange }: Props) {
+function ActiveInput(props: Props) {
+  const { type = "text", placeholder = "", value = "", onChange } = props;
+
+  const [active, setActive] = useState<boolean>(false);
+
+  const switchActive = () => {
+    setActive(!active);
+  };
+
   if (active) {
-    return <Input type={type} value={value} onChange={onChange} />;
+    return (
+      <Input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        onChange={onChange}
+        onBlur={switchActive}
+      />
+    );
   }
-  return <span>{value}</span>;
+  // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+  return <span onClick={switchActive}>{value || placeholder}</span>;
 }
 
 export default ActiveInput;

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -6,9 +6,10 @@ export interface ActiveInputProps {
   // eslint-disable-next-line react/require-default-props
   type?: string;
   // eslint-disable-next-line react/require-default-props
-  placeholder?: string;
+  placeholder?: string | number;
   // eslint-disable-next-line react/require-default-props, react/no-unused-prop-types
   multiline?: boolean;
+  // eslint-disable-next-line react/require-default-props
   register: UseFormRegisterReturn;
 }
 function ActiveInput(props: ActiveInputProps) {
@@ -45,7 +46,7 @@ function ActiveInput(props: ActiveInputProps) {
       <S.TextField
         {...register}
         type={type}
-        placeholder={placeholder}
+        placeholder={String(placeholder)}
         onChange={onChange}
         onBlur={onBlur}
         inputActive={inputActive}

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -2,23 +2,27 @@ import React, { useState } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import * as S from "./ActiveInput.styled";
 
-interface Props extends UseFormRegisterReturn {
+export interface ActiveInputProps extends UseFormRegisterReturn {
   // eslint-disable-next-line react/require-default-props
   type?: string;
   // eslint-disable-next-line react/require-default-props
   placeholder?: string;
+  // eslint-disable-next-line react/require-default-props, react/no-unused-prop-types
+  multiline?: boolean;
 }
-function ActiveInput(props: Props) {
+function ActiveInput(props: ActiveInputProps) {
   const {
+    multiline = false,
     type = "text",
     placeholder = "",
-    onChange,
+    onChange: formHookOnChange,
     onBlur: formHookOnBlur,
     ref,
     name,
   } = props;
 
   const [active, setActive] = useState<boolean>(false);
+  const [displayName, setDisplayName] = useState<string>("");
 
   const switchActive = () => {
     setActive(!active);
@@ -31,9 +35,16 @@ function ActiveInput(props: Props) {
     formHookOnBlur(e);
   };
 
+  const onChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ) => {
+    setDisplayName(e.target.value);
+    formHookOnChange(e);
+  };
+
   return (
     <>
-      <S.Input
+      <S.TextField
         type={type}
         placeholder={placeholder}
         onChange={onChange}
@@ -41,9 +52,12 @@ function ActiveInput(props: Props) {
         ref={ref}
         name={name}
         active={active}
+        multiline={multiline}
+        variant="standard"
+        fullWidth
       />
       <S.FormText onClick={switchActive} active={active}>
-        {placeholder}
+        {displayName || placeholder}
       </S.FormText>
     </>
   );

--- a/app/components/common/ActiveInput/ActiveInput.tsx
+++ b/app/components/common/ActiveInput/ActiveInput.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Input } from "@mui/material";
+
+interface Props {
+  type: string | undefined;
+  active: boolean;
+  value: string;
+  onChange: () => void;
+}
+function ActiveInput({ type = "text", active, value, onChange }: Props) {
+  if (active) {
+    return <Input type={type} value={value} onChange={onChange} />;
+  }
+  return <span>{value}</span>;
+}
+
+export default ActiveInput;

--- a/app/components/common/ActiveInput/index.ts
+++ b/app/components/common/ActiveInput/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as ActiveInput } from "./ActiveInput";

--- a/app/components/common/index.ts
+++ b/app/components/common/index.ts
@@ -1,0 +1,3 @@
+export { default as ActiveInput } from "./ActiveInput/ActiveInput";
+export { default as Drawer } from "./Drawer/Drawer";
+export { default as EmptyHome } from "./EmptyHome/EmptyHome";

--- a/app/mutations/postHint.ts
+++ b/app/mutations/postHint.ts
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 
 interface Request {
-  hintTitle: string;
+  hintTitle?: string;
   hintCode: string;
   contents: string;
   answer: string;

--- a/app/mutations/putHint.ts
+++ b/app/mutations/putHint.ts
@@ -6,7 +6,7 @@ import { AxiosResponse } from "axios";
 
 interface Request {
   id: number;
-  hintTitle: string;
+  hintTitle?: string;
   hintCode: string;
   contents: string;
   answer: string;


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 힌트 생성, 수정, 삭제 기능을 추가했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- activeInput이라는 컴포넌트를 추가했어요.
  - text인데 클릭하면 input 컴포넌트로 전환되는 커스텀 컴포넌트입니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- activeInput에서 input이 active가 아닌데 아직 text로 보이지 않고 input 컴포넌트로 보이는 문제
- Input창에서 tab 눌렀을 때 다음 input으로 이동하는 기능
- 테마 변경 시 활성화 중인 Input창 닫기, 초기화 시키기
- 로그인 시 loading에서 멈추는 문제 수정

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
