### PR TITLE
feat: update api

### DIFF
--- a/app/components/MakeThemeModal/MakeThemeModal.tsx
+++ b/app/components/MakeThemeModal/MakeThemeModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { usePostTheme } from "@/mutations/postTheme";
 import { usePutTheme } from "@/mutations/putTheme";
@@ -22,8 +22,20 @@ function MakeThemeModal() {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedTheme, setSelectedTheme] = useSelectedTheme();
+  const { register, handleSubmit, setValue } = useForm<FormValues>();
+  
+  
+  
+  useEffect(() => {
+    if (modalState.type === "put") {
+      setValue("title", selectedTheme.title);
+      setValue("timeLimit", selectedTheme.timeLimit);
+    } else {
+      setValue("title", "");
+      setValue("timeLimit", 0);
+    }
+  }, [selectedTheme, setValue, modalState.type]);
 
-  const { register, handleSubmit } = useForm<FormValues>();
   const { mutateAsync: postTheme } = usePostTheme();
   const { mutateAsync: putTheme } = usePutTheme();
 
@@ -32,7 +44,7 @@ function MakeThemeModal() {
     const submitData = {
       id: selectedTheme.id,
       title: data.title,
-      timeLimit: data.timeLimit
+      timeLimit: data.timeLimit,
     };
 
     if (modalState.type === "put") {
@@ -63,7 +75,6 @@ function MakeThemeModal() {
     placeholder: "입력해 주세요.",
     message: "손님에게는 보이지 않아요.",
     ...register("title"),
-    // variant: "filled",
   };
   const autoCompleteProps = {
     id: "timeLimit",
@@ -72,7 +83,6 @@ function MakeThemeModal() {
     type: "number",
     message: "손님이 사용할 타이머에 표시됩니다. (분 단위로 입력해 주세요.)",
     ...register("timeLimit"),
-    // variant: "filled",
   };
 
   const MakeThemeModalViewProps = {

--- a/app/components/MakeThemeModal/MakeThemeModal.tsx
+++ b/app/components/MakeThemeModal/MakeThemeModal.tsx
@@ -11,6 +11,7 @@ function MakeThemeModal() {
     id: number | undefined;
     title: string;
     timeLimit: number;
+    hintLimit: number;
   }
 
   interface TimeItem {
@@ -23,16 +24,16 @@ function MakeThemeModal() {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedTheme, setSelectedTheme] = useSelectedTheme();
   const { register, handleSubmit, setValue } = useForm<FormValues>();
-  
-  
-  
+
   useEffect(() => {
     if (modalState.type === "put") {
       setValue("title", selectedTheme.title);
       setValue("timeLimit", selectedTheme.timeLimit);
+      setValue("hintLimit", selectedTheme.hintLimit);
     } else {
       setValue("title", "");
       setValue("timeLimit", 0);
+      setValue("hintLimit", 0);
     }
   }, [selectedTheme, setValue, modalState.type]);
 
@@ -45,6 +46,7 @@ function MakeThemeModal() {
       id: selectedTheme.id,
       title: data.title,
       timeLimit: data.timeLimit,
+      hintLimit: data.hintLimit,
     };
 
     if (modalState.type === "put") {
@@ -69,14 +71,14 @@ function MakeThemeModal() {
     { label: "120", minute: 120 },
   ];
 
-  const textFieldProps = {
+  const themeNameProps = {
     id: "title",
     label: "테마 이름",
     placeholder: "입력해 주세요.",
     message: "손님에게는 보이지 않아요.",
     ...register("title"),
   };
-  const autoCompleteProps = {
+  const timeLimitProps = {
     id: "timeLimit",
     label: "시간",
     placeholder: "선택하기",
@@ -84,11 +86,20 @@ function MakeThemeModal() {
     message: "손님이 사용할 타이머에 표시됩니다. (분 단위로 입력해 주세요.)",
     ...register("timeLimit"),
   };
+  const hintLimitProps = {
+    id: "hintLimit",
+    label: "힌트갯수",
+    placeholder: "선택하기",
+    type: "number",
+    message: "손님이 사용할 흰트갯수가 표시됩니다.",
+    ...register("hintLimit"),
+  };
 
   const MakeThemeModalViewProps = {
     formProps,
-    textFieldProps,
-    autoCompleteProps,
+    themeNameProps,
+    timeLimitProps,
+    hintLimitProps,
     timeOption,
   };
 

--- a/app/components/MakeThemeModal/MakeThemeModalView.tsx
+++ b/app/components/MakeThemeModal/MakeThemeModalView.tsx
@@ -20,11 +20,16 @@ type Props = {
 
 function MakeThemeModalView(props: Props) {
   const [modalState, setModalState] = useModalState();
-  const toggleOffModalState = () =>
-    setModalState({ ...modalState, isOpen: false });
-
+  const ADD_THEME = "테마 추가하기";
+  const ADD_BTN = "추가하기";
+  const MODIFY_THEME = "테마 수정하기";
+  const MODIFY_BTN = "수정하기";
   const { watch } = useForm();
   const { formProps, timeOption, textFieldProps, autoCompleteProps } = props;
+
+  const toggleOffModalState = () => {
+    setModalState({ ...modalState, isOpen: false });
+  };
 
   useEffect(() => {
     // eslint-disable-next-line no-console
@@ -42,21 +47,38 @@ function MakeThemeModalView(props: Props) {
       >
         <S.Container>
           <S.CardWrap {...formProps}>
-            <S.Title>테마 추가하기</S.Title>
+            <S.Title>
+              {modalState.type === "post" ? ADD_THEME : MODIFY_THEME}
+            </S.Title>
             <S.Description>
               테마 추가 후 힌트를 등록할 수 있어요!
               <br />
               아래 정보는 언제든지 수정 가능합니다.
             </S.Description>
             <S.TextWrapper>
-              <TextField {...textFieldProps} fullWidth />
+              <TextField
+                {...textFieldProps}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                variant="filled"
+                fullWidth
+              />
               <S.Description>{textFieldProps.message}</S.Description>
               <Autocomplete
                 disablePortal
                 id="timeLimit"
                 options={timeOption}
                 renderInput={(params) => (
-                  <TextField {...params} {...autoCompleteProps} fullWidth />
+                  <TextField
+                    {...params}
+                    {...autoCompleteProps}
+                    variant="filled"
+                    InputLabelProps={{
+                      shrink: true,
+                    }}
+                    fullWidth
+                  />
                 )}
               />
               <S.Description>{autoCompleteProps.message}</S.Description>
@@ -70,7 +92,7 @@ function MakeThemeModalView(props: Props) {
                 onClick={toggleOffModalState}
                 type="submit"
               >
-                확인
+                {modalState.type === "post" ? ADD_BTN : MODIFY_BTN}
               </Button>
             </S.ButtonContainer>
           </S.CardWrap>

--- a/app/components/MakeThemeModal/MakeThemeModalView.tsx
+++ b/app/components/MakeThemeModal/MakeThemeModalView.tsx
@@ -13,8 +13,9 @@ type Props = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formProps: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  textFieldProps: Record<string, any>;
-  autoCompleteProps: Record<string, any>;
+  timeLimitProps: Record<string, any>;
+  themeNameProps: Record<string, any>;
+  hintLimitProps: Record<string, any>;
   timeOption: TimeItem[];
 };
 
@@ -25,7 +26,13 @@ function MakeThemeModalView(props: Props) {
   const MODIFY_THEME = "테마 수정하기";
   const MODIFY_BTN = "수정하기";
   const { watch } = useForm();
-  const { formProps, timeOption, textFieldProps, autoCompleteProps } = props;
+  const {
+    formProps,
+    timeOption,
+    themeNameProps,
+    timeLimitProps,
+    hintLimitProps,
+  } = props;
 
   const toggleOffModalState = () => {
     setModalState({ ...modalState, isOpen: false });
@@ -57,14 +64,14 @@ function MakeThemeModalView(props: Props) {
             </S.Description>
             <S.TextWrapper>
               <TextField
-                {...textFieldProps}
+                {...themeNameProps}
                 InputLabelProps={{
                   shrink: true,
                 }}
                 variant="filled"
                 fullWidth
               />
-              <S.Description>{textFieldProps.message}</S.Description>
+              <S.Description>{themeNameProps.message}</S.Description>
               <Autocomplete
                 disablePortal
                 id="timeLimit"
@@ -72,7 +79,7 @@ function MakeThemeModalView(props: Props) {
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    {...autoCompleteProps}
+                    {...timeLimitProps}
                     variant="filled"
                     InputLabelProps={{
                       shrink: true,
@@ -81,7 +88,16 @@ function MakeThemeModalView(props: Props) {
                   />
                 )}
               />
-              <S.Description>{autoCompleteProps.message}</S.Description>
+              <S.Description>{timeLimitProps.message}</S.Description>
+              <TextField
+                {...hintLimitProps}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                variant="filled"
+                fullWidth
+              />
+              <S.Description>{hintLimitProps.message}</S.Description>
             </S.TextWrapper>
             <S.ButtonContainer>
               <Button variant="text" onClick={toggleOffModalState}>

--- a/app/components/atoms/selectedTheme.atom.ts
+++ b/app/components/atoms/selectedTheme.atom.ts
@@ -9,13 +9,15 @@ interface SelectedTheme {
   id: number;
   title: string;
   timeLimit: number;
+  hintLimit: number;
 }
 
 const selectedThemeState = atom<SelectedTheme>({
   key: "selectedTheme",
-  default: { id: 0, title: "", timeLimit: 0 },
+  default: { id: 0, title: "", timeLimit: 0, hintLimit: 0 },
 });
 
 export const useSelectedTheme = () => useRecoilState(selectedThemeState);
 export const useSelectedThemeValue = () => useRecoilValue(selectedThemeState);
-export const useSelectedThemeWrite = () => useSetRecoilState(selectedThemeState);
+export const useSelectedThemeWrite = () =>
+  useSetRecoilState(selectedThemeState);

--- a/app/components/common/Drawer/Drawer.tsx
+++ b/app/components/common/Drawer/Drawer.tsx
@@ -30,7 +30,7 @@ function MainDrawer(props: Props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [modalState, setModalState] = useModalState();
   const toggleOnModalState = () =>
-    setModalState({ ...modalState, isOpen: true });
+    setModalState({ type:"post", isOpen: true });
   const logoProps = {
     src: "/images/svg/logo.svg",
     alt: "오늘의 방탈출",
@@ -41,8 +41,8 @@ function MainDrawer(props: Props) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   useEffect(() => {
     if (categories.length > 0) {
-      setSelectedIndex(categories[0].id);
-      setSelectedTheme(categories[0]);
+      setSelectedIndex(categories[categories.length-1].id);
+      setSelectedTheme(categories[categories.length-1]);
     }
   }, [categories, setSelectedTheme]);
 
@@ -67,7 +67,7 @@ function MainDrawer(props: Props) {
           </ListItemText>
         </ListItem>
 
-        {categories.map((theme) => (
+        {[...categories].reverse().map((theme) => (
           <ListItem key={theme.id}>
             <ListItemButton
               selected={selectedIndex === theme.id}

--- a/app/consts/login.ts
+++ b/app/consts/login.ts
@@ -1,4 +1,5 @@
 const LOGIN_TITLE = "오늘의 방탈출";
 const ADMIN_CODE = "관리자 코드";
+const ADMIN_PASSWORD = "비밀번호";
 
-export { LOGIN_TITLE, ADMIN_CODE };
+export { LOGIN_TITLE, ADMIN_CODE, ADMIN_PASSWORD };

--- a/app/login/Login.tsx
+++ b/app/login/Login.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
-import { ADMIN_CODE } from "@/consts/login";
+import { ADMIN_CODE, ADMIN_PASSWORD } from "@/consts/login";
 import { INPUT_MSG } from "@/consts/common";
 
 import { usePostLogin } from "@/mutations/postLogin";
@@ -9,6 +9,7 @@ import LoginView from "./LoginView";
 
 interface FormValues {
   adminCode: string;
+  password: string;
 }
 
 function Login() {
@@ -20,8 +21,8 @@ function Login() {
   } = usePostLogin();
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
-    const { adminCode } = data;
-    postLogin({ adminCode });
+
+    postLogin(data);
   };
   const formProps = {
     component: "form",
@@ -32,13 +33,24 @@ function Login() {
     flexDirection: "column",
   };
 
-  const textFieldProps = {
+  const adminCodeProps = {
     id: "filled-adminCode",
-    type: "password",
+    type: "text",
     variant: "filled",
     label: ADMIN_CODE,
     placeholder: INPUT_MSG,
     ...register("adminCode"),
+    error: isError,
+    sx:{marginBottom: "10px"}
+  };
+
+  const passwordProps = {
+    id: "filled-password",
+    type: "password",
+    variant: "filled",
+    label: ADMIN_PASSWORD,
+    placeholder: INPUT_MSG,
+    ...register("password"),
     error: isError,
   };
 
@@ -56,7 +68,8 @@ function Login() {
 
   const LoginViewProps = {
     formProps,
-    textFieldProps,
+    adminCodeProps,
+    passwordProps,
     buttonProps,
     logoProps,
     isLoading,

--- a/app/login/LoginView.tsx
+++ b/app/login/LoginView.tsx
@@ -8,8 +8,14 @@ import * as S from "./LoginView.styled";
 type Props = Record<string, any>;
 
 function LoginView(props: Props) {
-  const { formProps, textFieldProps, buttonProps, logoProps, isLoading } =
-    props;
+  const {
+    formProps,
+    adminCodeProps,
+    passwordProps,
+    buttonProps,
+    logoProps,
+    isLoading,
+  } = props;
 
   return (
     <S.Wrapper>
@@ -19,7 +25,8 @@ function LoginView(props: Props) {
       <Image {...logoProps} />
       <S.Title>{LOGIN_TITLE}</S.Title>
       <Box {...formProps}>
-        <TextField {...textFieldProps} />
+        <TextField {...adminCodeProps} />
+        <TextField {...passwordProps} />
         <S.LoginButton {...buttonProps}>로그인</S.LoginButton>
       </Box>
     </S.Wrapper>

--- a/app/mutations/postLogin.ts
+++ b/app/mutations/postLogin.ts
@@ -7,6 +7,7 @@ import { useIsLoggedInWrite } from "@/components/atoms/account.atom";
 
 interface Request {
   adminCode: string;
+  password: string;
 }
 
 interface LoginResponse {
@@ -21,8 +22,7 @@ type Response = ApiResponse<LoginResponse>;
 const URL_PATH = `/v1/auth/login`;
 const MUTATION_KEY = [URL_PATH];
 
-export const postLogin = async ({ adminCode }: Request) => {
-  const data: Request = { adminCode };
+export const postLogin = async ( data : Request) => {
   const res = await apiClient.post<Request, AxiosResponse<Response>>(
     URL_PATH,
     data

--- a/app/queries/getThemeList.ts
+++ b/app/queries/getThemeList.ts
@@ -4,7 +4,13 @@ import { useQuery } from "@tanstack/react-query";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 
 type Request = void;
-export type Theme = { id: number; title: string; timeLimit: number };
+export type Theme = {
+  id: number;
+  title: string;
+  timeLimit: number;
+  hintLimit: number;
+};
+
 export type Themes = Theme[];
 
 type Response = ApiResponse<Themes>;


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 로그인, 테마 추가 api가 변경되어 코드를 추가했어요
<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 로그인 비밀번호 입력, 힌트 갯수 입력창을 추가했어요

<br><br>

### 💡 필요한 후속작업이 있어요.

- 로그인 후 새로고침 없이 테마 목록 출력, 테마 클릭시 바로 힌트 업데이트 

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
