### PR TITLE
fix: insert access token

### DIFF
--- a/app/home/Home.tsx
+++ b/app/home/Home.tsx
@@ -1,11 +1,27 @@
-import React from "react";
+"use client";
+
+import React, { useEffect } from "react";
 
 import { useGetThemeList } from "@/queries/getThemeList";
+
+import { apiClient } from "@/lib/reactQueryProvider";
+import { getAccessToken } from "@/uilts/localStorage";
+
+import { useIsLoggedInWrite } from "@/components/atoms/account.atom";
 
 import HomeView from "./HomeView";
 
 function Home() {
   const { data: categories = [] } = useGetThemeList();
+  const accountToken = getAccessToken();
+  const setIsLoggedIn = useIsLoggedInWrite();
+
+  useEffect(() => {
+    if (accountToken) {
+      apiClient.defaults.headers.common.Authorization = accountToken;
+      setIsLoggedIn(true);
+    }
+  }, [accountToken, setIsLoggedIn]);
 
   const themeAllProps = {
     categories,

--- a/app/home/Home.tsx
+++ b/app/home/Home.tsx
@@ -3,29 +3,28 @@
 import React, { useEffect } from "react";
 
 import { useGetThemeList } from "@/queries/getThemeList";
+import useCheckSignIn from "@/hooks/useCheckSignIn";
 
-import { apiClient } from "@/lib/reactQueryProvider";
-import { getAccessToken } from "@/uilts/localStorage";
-
-import { useIsLoggedInWrite } from "@/components/atoms/account.atom";
-
+import { useRouter } from "next/navigation";
 import HomeView from "./HomeView";
 
 function Home() {
   const { data: categories = [] } = useGetThemeList();
-  const accountToken = getAccessToken();
-  const setIsLoggedIn = useIsLoggedInWrite();
+  const router = useRouter();
+
+  const isSignIn = useCheckSignIn();
 
   useEffect(() => {
-    if (accountToken) {
-      apiClient.defaults.headers.common.Authorization = accountToken;
-      setIsLoggedIn(true);
+    if (!isSignIn) {
+      router.push("/");
     }
-  }, [accountToken, setIsLoggedIn]);
+  }, [isSignIn, router]);
 
   const themeAllProps = {
     categories,
   };
+
+  if (!isSignIn) return <div>Loading...</div>;
 
   return <HomeView {...themeAllProps} />;
 }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import Home from "./Home";
 

--- a/app/hooks/useCheckSignIn.ts
+++ b/app/hooks/useCheckSignIn.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+import { apiClient } from "@/lib/reactQueryProvider";
+import { getAccessToken } from "@/uilts/localStorage";
+
+import { useIsLoggedIn } from "@/components/atoms/account.atom";
+
+const useCheckSignIn = () => {
+  const accessToken = getAccessToken();
+  const [isLoggedIn, setIsLoggedIn] = useIsLoggedIn();
+
+  useEffect(() => {
+    if (accessToken) {
+      apiClient.defaults.headers.common.Authorization = `Bearer ${accessToken.replace(
+        /^"(.*)"$/,
+        "$1"
+      )}`;
+      setIsLoggedIn(true);
+    }
+  }, [accessToken, setIsLoggedIn]);
+
+  return accessToken && isLoggedIn;
+};
+
+export default useCheckSignIn;

--- a/app/login/Login.tsx
+++ b/app/login/Login.tsx
@@ -11,8 +11,8 @@ import { useIsLoggedIn } from "@/components/atoms/account.atom";
 import { usePostLogin } from "@/mutations/postLogin";
 
 import { getAccessToken } from "@/uilts/localStorage";
-
 import { apiClient } from "@/lib/reactQueryProvider";
+
 import LoginView from "./LoginView";
 
 interface FormValues {
@@ -22,22 +22,22 @@ interface FormValues {
 
 function Login() {
   const router = useRouter();
+  const accountToken = getAccessToken();
   const [isLoggedIn, setIsLoggedIn] = useIsLoggedIn();
-  const { register, handleSubmit } = useForm<FormValues>();
   const {
     mutateAsync: postLogin,
     isLoading = false,
     isError = false,
   } = usePostLogin();
 
-  useEffect(() => {
-    const accountToken = getAccessToken();
+  const { register, handleSubmit } = useForm<FormValues>();
 
+  useEffect(() => {
     if (accountToken) {
       apiClient.defaults.headers.common.Authorization = accountToken;
       setIsLoggedIn(true);
     }
-  }, [setIsLoggedIn]);
+  }, [accountToken, setIsLoggedIn]);
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     postLogin(data);

--- a/app/login/Login.tsx
+++ b/app/login/Login.tsx
@@ -1,18 +1,15 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { ADMIN_CODE, ADMIN_PASSWORD } from "@/consts/login";
 import { INPUT_MSG } from "@/consts/common";
 
-import { useIsLoggedIn } from "@/components/atoms/account.atom";
+import { useIsLoggedInValue } from "@/components/atoms/account.atom";
 import { usePostLogin } from "@/mutations/postLogin";
-
-import { getAccessToken } from "@/uilts/localStorage";
-import { apiClient } from "@/lib/reactQueryProvider";
-
+import useCheckSignIn from "@/hooks/useCheckSignIn";
 import LoginView from "./LoginView";
 
 interface FormValues {
@@ -22,8 +19,7 @@ interface FormValues {
 
 function Login() {
   const router = useRouter();
-  const accountToken = getAccessToken();
-  const [isLoggedIn, setIsLoggedIn] = useIsLoggedIn();
+  const isLoggedIn = useIsLoggedInValue();
   const {
     mutateAsync: postLogin,
     isLoading = false,
@@ -32,12 +28,7 @@ function Login() {
 
   const { register, handleSubmit } = useForm<FormValues>();
 
-  useEffect(() => {
-    if (accountToken) {
-      apiClient.defaults.headers.common.Authorization = accountToken;
-      setIsLoggedIn(true);
-    }
-  }, [accountToken, setIsLoggedIn]);
+  useCheckSignIn();
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     postLogin(data);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,5 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import Login from "./login/Login";
 
-import { getAccessToken } from "./uilts/localStorage";
-import { useIsLoggedIn } from "./components/atoms/account.atom";
-
 export default function LoginPage() {
-  const router = useRouter();
-  const [isLoggedIn, setIsLoggedIn] = useIsLoggedIn();
-
-  useEffect(() => {
-    const accountToken = getAccessToken();
-
-    if (accountToken) {
-      setIsLoggedIn(true);
-    }
-  }, [setIsLoggedIn]);
-
-  if (isLoggedIn) {
-    router.push("/home");
-    return <div>Loading...</div>;
-  }
-
   return <Login />;
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 로그인 시 바로 access token이 헤더에 담기지 않는 문제를 수정했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 가장 상위 page.tsx 파일의 내용을 Login 컴포넌트로 이동시켰습니다.

- `Home/pages.tsx` 컴포넌트의 'use client'를 `Home.tsx`로 이동시켰습니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- 힌트 리스트 로딩 문제 개선 작업

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
