### PR TITLE
feat: hint

### DIFF
--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -8,6 +8,7 @@ import {
   useIsActiveHintItemState,
   useIsOpenDeleteDialogStateWrite,
 } from "../atoms/hints.atom";
+import Dialog from "../common/Dialog/Dialog";
 
 type Props = {
   active: boolean;
@@ -17,6 +18,7 @@ type Props = {
   id?: number;
   // eslint-disable-next-line react/require-default-props
   hintData?: FormValues;
+  // dialogOpen: () => void;
 };
 
 interface FormValues {
@@ -28,8 +30,11 @@ interface FormValues {
 
 function HintManager(props: Props) {
   const { id, active, close, type, hintData } = props;
+  const [open, setOpen] = useState<boolean>(false);
+
   const [submitDisable, setSubmitDisable] = useState<boolean>(false);
-  const { register, handleSubmit, setValue, watch } = useForm<FormValues>();
+  const { register, handleSubmit, reset, setValue, watch } =
+    useForm<FormValues>();
   const { mutateAsync: postHint, isSuccess: postHintSuccess } = usePostHint();
   const { mutateAsync: putHint } = usePutHint();
   const { id: themeId } = useSelectedThemeValue();
@@ -37,11 +42,10 @@ function HintManager(props: Props) {
   const formRef = useRef<HTMLFormElement>(null);
   const [isActiveHintItemState, setIsActiveHintItemState] =
     useIsActiveHintItemState();
-
   useEffect(() => {
-    if (postHintSuccess) {
-      close();
-    }
+    // if (postHintSuccess) {
+    //   close();
+    // }
   }, [close, postHintSuccess]);
 
   useEffect(() => {
@@ -89,14 +93,13 @@ function HintManager(props: Props) {
   useEffect(() => {
     if (
       !formValue.progress ||
-      !(formValue.hintCode.length===4) ||
+      !(formValue.hintCode.length === 4) ||
       !formValue.contents ||
       !formValue.answer
     ) {
       setSubmitDisable(true);
-    }else{
+    } else {
       setSubmitDisable(false);
-
     }
   }, [formValue]);
 
@@ -134,6 +137,8 @@ function HintManager(props: Props) {
         id: Number(id),
       });
     }
+    reset();
+    close();
   };
 
   const isCurrentHintActive = isActiveHintItemState === id;
@@ -141,7 +146,14 @@ function HintManager(props: Props) {
   const activateForm = (event: React.MouseEvent) => {
     event.stopPropagation();
     if (!id) return;
+
     setIsActiveHintItemState(id);
+    // close();
+    setOpen(true);
+  };
+
+  const stopEvent = (event: React.MouseEvent) => {
+    event.stopPropagation();
   };
 
   const deactivateForm = (event: MouseEvent) => {
@@ -202,7 +214,7 @@ function HintManager(props: Props) {
   const makeHintButtonProps = {
     type: "submit",
     variant: "contained",
-    disabled: submitDisable
+    disabled: submitDisable,
   };
 
   const makeHintProps = {
@@ -214,11 +226,22 @@ function HintManager(props: Props) {
     deleteButtonProps,
     makeHintButtonProps,
     activateForm: isCurrentHintActive,
+    stopEvent,
   };
 
   if (!active) return null;
 
-  return <HintManagerView {...makeHintProps} />;
+  return (
+    <>
+      <HintManagerView {...makeHintProps} />
+      <Dialog
+        open={open}
+        handleDialogClose={() => setOpen(false)}
+        type="hintPut"
+        handleHint={close}
+      />
+    </>
+  );
 }
 
 export default HintManager;

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -238,7 +238,7 @@ function HintManager(props: Props) {
         open={open}
         handleDialogClose={() => setOpen(false)}
         type="hintPut"
-        handleHint={close}
+        handleBtn={close}
       />
     </>
   );

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { usePostHint } from "@/mutations/postHint";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { usePutHint } from "@/mutations/putHint";
@@ -28,7 +28,7 @@ interface FormValues {
 
 function HintManager(props: Props) {
   const { id, active, close, type, hintData } = props;
-
+  const [submitDisable, setSubmitDisable] = useState<boolean>(false);
   const { register, handleSubmit, setValue, watch } = useForm<FormValues>();
   const { mutateAsync: postHint, isSuccess: postHintSuccess } = usePostHint();
   const { mutateAsync: putHint } = usePutHint();
@@ -84,6 +84,21 @@ function HintManager(props: Props) {
     // eslint-disable-next-line consistent-return
     return () => subscription.unsubscribe();
   }, [hintData, watch]);
+
+  const formValue = watch();
+  useEffect(() => {
+    if (
+      !formValue.progress ||
+      !(formValue.hintCode.length===4) ||
+      !formValue.contents ||
+      !formValue.answer
+    ) {
+      setSubmitDisable(true);
+    }else{
+      setSubmitDisable(false);
+
+    }
+  }, [formValue]);
 
   const openDeleteDialog = () => {
     if (!id) return;
@@ -187,6 +202,7 @@ function HintManager(props: Props) {
   const makeHintButtonProps = {
     type: "submit",
     variant: "contained",
+    disabled: submitDisable
   };
 
   const makeHintProps = {

--- a/app/components/HintManager/HintManagerView.styled.ts
+++ b/app/components/HintManager/HintManagerView.styled.ts
@@ -35,6 +35,15 @@ export const InputsWrapper = styled.div`
     height: 36px;
     background-color: #ffffff14;
     color: #fff;
+    & input[type="number"]::-webkit-inner-spin-button,
+    & input[type="number"]::-webkit-outer-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    & input[type="number"] {
+      -moz-appearance: textfield; /* Firefox에서 화살표를 숨기기 위한 설정 */
+    }
   }
 
   .TextareaBox {

--- a/app/components/HintManager/HintManagerView.tsx
+++ b/app/components/HintManager/HintManagerView.tsx
@@ -18,6 +18,7 @@ interface Props {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   makeHintButtonProps: Record<string, any>;
   activateForm: boolean;
+  stopEvent: (event: React.MouseEvent) => void;
 }
 
 const DELETE = "삭제하기";
@@ -33,18 +34,35 @@ function HintManagerView(props: Props) {
     makeHintButtonProps,
     formProps,
     activateForm,
+    stopEvent,
   } = props;
 
   return (
     <Box {...formProps}>
       <S.Wrapper active={activateForm}>
         <S.InputsWrapper>
-          <Input className="inputBox" {...hintCodeInputProps} />
-          <Input className="inputBox" {...progressInputProps} />
-          <Input className="TextareaBox" {...contentsInputProps} />
-          <Input className="TextareaBox" {...answerInputProps} />
+          <Input
+            className="inputBox"
+            onClick={stopEvent}
+            {...hintCodeInputProps}
+          />
+          <Input
+            className="inputBox"
+            onClick={stopEvent}
+            {...progressInputProps}
+          />
+          <Input
+            className="TextareaBox"
+            onClick={stopEvent}
+            {...contentsInputProps}
+          />
+          <Input
+            className="TextareaBox"
+            onClick={stopEvent}
+            {...answerInputProps}
+          />
         </S.InputsWrapper>
-        <S.FunctionButtonsWrapper>
+        <S.FunctionButtonsWrapper onClick={stopEvent}>
           <Button {...deleteButtonProps}>{DELETE}</Button>
           <Button {...makeHintButtonProps}>{MAKE_HINT}</Button>
         </S.FunctionButtonsWrapper>

--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -139,6 +139,7 @@ function MakeThemePage() {
     <>
       <MakeThemeModalView {...MakeThemeModalViewProps} />
       <Dialog
+        handleBtn={() => setModalState({ ...modalState, isOpen: false })}
         open={open}
         handleDialogClose={() => setOpen(false)}
         type={modalState.type === "post" ? "themePost" : "themePut"}

--- a/app/components/common/Dialog/Dialog.tsx
+++ b/app/components/common/Dialog/Dialog.tsx
@@ -6,26 +6,30 @@ type ContentType = "hintPut" | "themePut" | "hintPost" | "themePost";
 interface Props {
   open: boolean;
   handleDialogClose: () => void;
+  handleHint: () => void;
   type: ContentType;
 }
 
 function Dialog(props: Props) {
   const [modalState, setModalState] = useModalState();
-  const { open, handleDialogClose, type } = props;
-
+  const { open, handleDialogClose, type, handleHint} = props;
 
   const handleCancleDialog = () => {
     handleDialogClose();
     setModalState({ ...modalState, isOpen: false });
   };
 
+  const handleHintCancleDialog = () => {
+    handleHint();
+    handleDialogClose();
+  };
   // 힌트 함수 추가
 
   const content = {
     hintPost: {
       title: "힌트 추가를 그만두시겠어요?",
       description: "작성된 정보는 모두 사라집니다.",
-      handleDialog: ()=>{},
+      handleDialog: handleHintCancleDialog,
     },
     themePost: {
       title: "테마 추가를 그만두시겠어요?",
@@ -35,14 +39,13 @@ function Dialog(props: Props) {
     hintPut: {
       title: "힌트 수정을 그만두시겠어요?",
       description: "수정사항은 사라집니다.",
-      handleDialog: ()=>{},
+      handleDialog: handleHintCancleDialog,
     },
     themePut: {
       title: "테마 수정을 그만두시겠어요",
       description: "수정사항은 사라집니다.",
       handleDialog: handleCancleDialog,
     },
-
   };
 
   const DialogProps = {

--- a/app/components/common/Dialog/Dialog.tsx
+++ b/app/components/common/Dialog/Dialog.tsx
@@ -1,4 +1,3 @@
-import { useModalState } from "@/components/atoms/modals.atom";
 import DialogView from "./DialogView";
 
 type ContentType = "hintPut" | "themePut" | "hintPost" | "themePost";
@@ -6,51 +5,45 @@ type ContentType = "hintPut" | "themePut" | "hintPost" | "themePost";
 interface Props {
   open: boolean;
   handleDialogClose: () => void;
-  handleHint: () => void;
+  handleBtn: () => void;
   type: ContentType;
 }
 
 function Dialog(props: Props) {
-  const [modalState, setModalState] = useModalState();
-  const { open, handleDialogClose, type, handleHint} = props;
+  const { open, handleDialogClose, type, handleBtn } = props;
 
   const handleCancleDialog = () => {
+    handleBtn();
+
     handleDialogClose();
-    setModalState({ ...modalState, isOpen: false });
   };
 
-  const handleHintCancleDialog = () => {
-    handleHint();
-    handleDialogClose();
-  };
+
   // 힌트 함수 추가
 
   const content = {
     hintPost: {
       title: "힌트 추가를 그만두시겠어요?",
       description: "작성된 정보는 모두 사라집니다.",
-      handleDialog: handleHintCancleDialog,
     },
     themePost: {
       title: "테마 추가를 그만두시겠어요?",
       description: "작성된 정보는 모두 사라집니다.",
-      handleDialog: handleCancleDialog,
     },
     hintPut: {
       title: "힌트 수정을 그만두시겠어요?",
       description: "수정사항은 사라집니다.",
-      handleDialog: handleHintCancleDialog,
     },
     themePut: {
       title: "테마 수정을 그만두시겠어요",
       description: "수정사항은 사라집니다.",
-      handleDialog: handleCancleDialog,
     },
   };
 
   const DialogProps = {
     open,
     handleDialogClose,
+    handleCancleDialog,
     content: { ...content[type] },
   };
 

--- a/app/components/common/Dialog/DialogView.tsx
+++ b/app/components/common/Dialog/DialogView.tsx
@@ -12,13 +12,14 @@ interface Props {
   open: boolean;
   handleDialogClose: () => void;
   content:any;
+  handleCancleDialog: () => void;
 }
 
 const CANCEL = "취소";
 const STAY = "그만두기";
 
 function DeleteThemeDialogView(props: Props) {
-  const { open, handleDialogClose, content } = props;
+  const { open, handleDialogClose, content, handleCancleDialog } = props;
   
   return (
     <Dialog
@@ -37,7 +38,7 @@ function DeleteThemeDialogView(props: Props) {
       </DialogContent>
       <DialogActions>
         <Button onClick={handleDialogClose}>{CANCEL}</Button>
-        <Button onClick={content.handleDialog} autoFocus>
+        <Button onClick={handleCancleDialog} autoFocus>
           {STAY}
         </Button>
       </DialogActions>

--- a/app/home/Home.tsx
+++ b/app/home/Home.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useGetThemeList } from "@/queries/getThemeList";
 import useCheckSignIn from "@/hooks/useCheckSignIn";
 import { useRouter } from "next/navigation";
-import { useModalStateValue } from "@/components/atoms/modals.atom";
+import { useModalState } from "@/components/atoms/modals.atom";
 import Dialog from "@/components/common/Dialog/Dialog";
 import { useSnackBarInfo } from "@/components/atoms/snackBar.atom";
 import SnackBar from "@/components/SnackBar/SnackBar";
@@ -16,7 +16,7 @@ function Home() {
   const [open, setOpen] = useState<boolean>(false);
   const [snackInfo, setSnackBarInfo] = useSnackBarInfo();
 
-  const modalState = useModalStateValue();
+  const [modalState, setModalState] = useModalState();
 
   const handleDialog = () => {
     setOpen(!open);
@@ -50,6 +50,7 @@ function Home() {
       <HomeView {...themeAllProps} />
       <Dialog
         open={open}
+        handleBtn={() => setModalState({ ...modalState, isOpen: false })}
         handleDialogClose={() => setOpen(false)}
         type={modalState.type === "post" ? "themePost" : "themePut"}
       />


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 힌트 작성 수정 부분 validator
- 에러 표시 (스낵바)
- 힌트 작성 중 벗어나는 경우 알림 띄우기
- 힌트 보는 곳에서 input 이외 영역 클릭 시 닫히는 기능
- 2번 이상 힌트 추가할 때 hintManager가 안뜨는 오류생기는 부분 수정
`
  useEffect(() => {
    if (postHintSuccess) {
      close();
    }
  }, [close, postHintSuccess]);
`
이부분이 계속 실행이 되는 듯해서 onSubmit되면  close()되고 reset()으로 초기화했습니다!
- input 숫자 입력 오른쪽 화살표 버튼 제거

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.



<br><br>

### 💡 필요한 후속작업이 있어요.

-  현재는 input이 아닌 영역을 클릭하면 무조건 알림이 뜨는데 
drawer이나 테마 추가 버튼 클릭시
입력값이 없거나 수정값이 변하지 않을 경우 
다른 힌트를 수정하는 경우 추가 구현 예정

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
