### PR TITLE
fix: hint dialog

### DIFF
--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -159,8 +159,7 @@ function HintManager(props: Props) {
     if (!id) return;
 
     setIsActiveHintItemState(id);
-    // // close();
-    // setOpen(true);
+
   };
 
   const stopEvent = (event: React.MouseEvent) => {
@@ -169,7 +168,21 @@ function HintManager(props: Props) {
 
   const cancelInput = (event: React.MouseEvent) => {
     event.stopPropagation();
-    setOpen(true);
+
+       
+    if (
+      type !== MAKE &&
+      hintData &&
+      hintData.progress === formValue.progress &&
+      hintData.hintCode === formValue.hintCode &&
+      hintData.contents === formValue.contents &&
+      hintData.answer === formValue.answer
+    ) {
+      close();
+    } else {
+      setOpen(true);
+    }
+  
   };
 
   const deactivateForm = (event: MouseEvent) => {

--- a/app/components/HintManager/HintManager.tsx
+++ b/app/components/HintManager/HintManager.tsx
@@ -53,11 +53,6 @@ function HintManager(props: Props) {
   const [isActiveHintItemState, setIsActiveHintItemState] =
     useIsActiveHintItemState();
 
-  // useEffect(() => {
-  //   // if (postHintSuccess) {
-  //   //   close();
-  //   // }
-  // }, [close, postHintSuccess]);
 
   useEffect(() => {
     if (!hintData) return;
@@ -159,7 +154,6 @@ function HintManager(props: Props) {
     if (!id) return;
 
     setIsActiveHintItemState(id);
-
   };
 
   const stopEvent = (event: React.MouseEvent) => {
@@ -169,7 +163,6 @@ function HintManager(props: Props) {
   const cancelInput = (event: React.MouseEvent) => {
     event.stopPropagation();
 
-       
     if (
       type !== MAKE &&
       hintData &&
@@ -182,7 +175,6 @@ function HintManager(props: Props) {
     } else {
       setOpen(true);
     }
-  
   };
 
   const deactivateForm = (event: MouseEvent) => {

--- a/app/components/MakeThemePage/MakeThemePageView.styled.ts
+++ b/app/components/MakeThemePage/MakeThemePageView.styled.ts
@@ -22,12 +22,14 @@ export const Description = styled.p`
   font-size: ${(props) => props.theme.fontSize.sm};
   font-weight: ${(props) => props.theme.fontWeight.light};
   margin: 4px 16px 20px;
+  line-height: 20px;
   color: rgba(255, 255, 255, 1);
 `;
 
 export const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  margin-bottom: 42px;
 `;
 
 export const ButtonContainer = styled(Grid)`
@@ -37,16 +39,18 @@ export const ButtonContainer = styled(Grid)`
 
 export const CancleButton = styled(Button)``;
 
-export const SubmitButton = styled(Button)``;
+export const SubmitButton = styled(Button)`
+  width: 97px;
+`;
 
 export const StyledNumberInput = styled(TextField)`
-  & input[type='number']::-webkit-inner-spin-button,
-  & input[type='number']::-webkit-outer-spin-button {
+  & input[type="number"]::-webkit-inner-spin-button,
+  & input[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
 
-  & input[type='number'] {
+  & input[type="number"] {
     -moz-appearance: textfield; /* Firefox에서 화살표를 숨기기 위한 설정 */
   }
 `;

--- a/app/components/ThemeDetail/ThemeDetail.styled.ts
+++ b/app/components/ThemeDetail/ThemeDetail.styled.ts
@@ -15,7 +15,7 @@ export const Title = styled.div`
 `;
 
 export const MiddleTitle = styled.div`
-  font-size: 1rem;
+  font-size: ${(props) => props.theme.fontSize.sm};
   opacity: 0.7;
 `;
 

--- a/app/components/ThemeDetail/ThemeDetail.tsx
+++ b/app/components/ThemeDetail/ThemeDetail.tsx
@@ -2,20 +2,34 @@ import React, { useState } from "react";
 import { useSelectedThemeValue } from "../atoms/selectedTheme.atom";
 import DeleteDialog from "../common/DeleteDialog/DeleteDialog";
 import ThemeDetailView from "./ThemeDetailView";
+import Dialog from "../common/Dialog/Dialog";
+import { useActiveHintState } from "../atoms/activeHint.atom";
+import { useModalStateWrite } from "../atoms/modals.atom";
 
 function ThemeDetail() {
   const selectedTheme = useSelectedThemeValue();
   const [open, setOpen] = useState<boolean>(false);
-  
+  const [activeHint, setActiveHint] = useActiveHintState();
+  const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+  const  setModalState = useModalStateWrite();
 
   return (
     <>
-      <ThemeDetailView handleOpen={() => setOpen(true)} />
+      <ThemeDetailView handleOpen={() => setOpen(true)} handleDialogOpen={()=>setDialogOpen(true)} />
       <DeleteDialog
         open={open}
         handleDialogClose={() => setOpen(false)}
         id={selectedTheme.id}
         type="themeDelete"
+      />
+      <Dialog
+        handleBtn={() => {
+          setModalState({isOpen:true, type: "put"})
+          setActiveHint({isOpen:false, type: "put"})
+        }}
+        open={dialogOpen}
+        handleDialogClose={() => setDialogOpen(false)}
+        type={activeHint.type === "post" ? "hintPost" : "hintPut"}
       />
     </>
   );

--- a/app/components/ThemeDetail/ThemeDetailView.tsx
+++ b/app/components/ThemeDetail/ThemeDetailView.tsx
@@ -1,28 +1,35 @@
 import React, { useState } from "react";
 import { Stack, Grid, IconButton, Menu, MenuItem } from "@mui/material";
-import { useSelectedTheme } from "@/components/atoms/selectedTheme.atom";
-import { useModalState } from "@/components/atoms/modals.atom";
+import { useSelectedThemeValue } from "@/components/atoms/selectedTheme.atom";
+import { useModalStateWrite } from "@/components/atoms/modals.atom";
+import { useActiveHintStateValue } from "@/components/atoms/activeHint.atom";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import EditIcon from "@mui/icons-material/Edit";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import DeleteIcon from "@mui/icons-material/Delete";
 import HintList from "../HintList/HintList";
 import * as S from "./ThemeDetail.styled";
 
 type Props = {
   handleOpen: () => void;
+  handleDialogOpen: () => void;
 };
 
 function ThemeDetailView(props: Props) {
-  const { handleOpen } = props;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [selectedTheme, setSelectedTheme] = useSelectedTheme();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [modalState, setModalState] = useModalState();
-  const [state1, setState1] = useState(false);
-  const toggleOnModalState = () => setModalState({ isOpen: true, type: "put" });
+  const { handleOpen, handleDialogOpen } = props;
+  const selectedTheme = useSelectedThemeValue();
+  const setModalState = useModalStateWrite();
+  const activeHint = useActiveHintStateValue();
+
+  const [menuState, setMenuState] = useState(false);
+  const toggleOnModalState = () => {
+    if (activeHint.isOpen) {
+      handleDialogOpen();
+    } else {
+      setModalState({ isOpen: true, type: "put" });
+    }
+  };
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -32,7 +39,7 @@ function ThemeDetailView(props: Props) {
   };
   const closeMenu = () => {
     setAnchorEl(null);
-    setState1(!state1);
+    setMenuState(!menuState);
   };
 
   const handleMenu = () => {

--- a/app/components/ThemeDetail/ThemeDetailView.tsx
+++ b/app/components/ThemeDetail/ThemeDetailView.tsx
@@ -94,7 +94,7 @@ function ThemeDetailView(props: Props) {
                 onClick={handleMenu}
                 sx={{
                   width: "200px",
-                  height: "56px",
+                  // height: "56px",
                   backgroundColor: "#211F26",
                 }}
               >

--- a/app/components/atoms/activeHint.atom.ts
+++ b/app/components/atoms/activeHint.atom.ts
@@ -1,0 +1,20 @@
+import {
+  atom,
+  useRecoilValue,
+  useRecoilState,
+  useSetRecoilState,
+} from "recoil";
+
+interface ActiveHint {
+  isOpen: boolean;
+  type: "post" | "put";
+}
+
+const activeHintState = atom<ActiveHint>({
+  key: "activeHint",
+  default: { isOpen: false, type: "post" },
+});
+
+export const useActiveHintState = () => useRecoilState(activeHintState);
+export const useActiveHintStateValue = () => useRecoilValue(activeHintState);
+export const useActiveHintStateWrite = () => useSetRecoilState(activeHintState);

--- a/app/style/ThemeMUI.json
+++ b/app/style/ThemeMUI.json
@@ -421,7 +421,8 @@
         "root": {
           "color": "#fff",
           "padding": "unset",
-          "height": "68%"
+          "height": "68%",
+          "fontSize": "14px"
         }
       }
     },
@@ -582,11 +583,15 @@
         "color": "default"
       },
       "styleOverrides": {
-        "root": {},
+        "root": {
+        },
         "paper": {
           "backgroundColor": "#211F26",
           "boxShadow": "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
-          "color": "#E6E0E9"
+          "color": "#E6E0E9",
+          "&:hover": {
+            "backgroundColor": "rgba(255, 255, 255, 0.2)"
+          }
         }
       }
     },


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 힌트 열린 상태에서 새로운 힌트추가/ 테마수정 누를 시 다이얼로그 뜨도록
- 다이얼로그/ 테마 추가 페이지 스타일 수정

<br><br>


<br><br>

### 💡 필요한 후속작업이 있어요.

- 힌트열린 상태에서 drawer 에 있는 버튼을 누를시에도 다이얼로그가 뜨도록 해야하는데 이 부분이 잘안돼서 🥲 열심히 해보겠습니다
- 페이지 분리 작업

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
