### PR TITLE
fix: layout

### DIFF
--- a/app/components/MakeThemePage/MakeThemePage.tsx
+++ b/app/components/MakeThemePage/MakeThemePage.tsx
@@ -1,9 +1,12 @@
+"use client";
+
 import React, { useState, useEffect } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { usePostTheme } from "@/mutations/postTheme";
 import { usePutTheme } from "@/mutations/putTheme";
 import { useSelectedTheme } from "@/components/atoms/selectedTheme.atom";
 import { useModalState } from "@/components/atoms/modals.atom";
+import { useRouter } from "next/navigation";
 import MakeThemeModalView from "./MakeThemePageView";
 import Dialog from "../common/Dialog/Dialog";
 
@@ -20,6 +23,8 @@ function MakeThemePage() {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedTheme, setSelectedTheme] = useSelectedTheme();
+  const router = useRouter();
+
   const {
     register,
     handleSubmit,
@@ -61,7 +66,6 @@ function MakeThemePage() {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onSubmit: SubmitHandler<FormValues> = (data) => {
-    console.log("Submitting", data);
 
     const submitData = {
       id: selectedTheme.id,
@@ -73,9 +77,12 @@ function MakeThemePage() {
     if (modalState.type === "put") {
       putTheme(submitData);
       setModalState({ ...modalState, isOpen: false });
+      router.push(`/home?title=${encodeURIComponent(selectedTheme.title)}`);
     } else {
       postTheme(data);
       setModalState({ ...modalState, isOpen: false });
+      router.push(`/home?title=${encodeURIComponent(data.title)}`);
+
     }
   };
 
@@ -139,7 +146,9 @@ function MakeThemePage() {
     <>
       <MakeThemeModalView {...MakeThemeModalViewProps} />
       <Dialog
-        handleBtn={() => setModalState({ ...modalState, isOpen: false })}
+        handleBtn={() =>
+          router.push(`/home?title=${encodeURIComponent(selectedTheme.title)}`)
+        }
         open={open}
         handleDialogClose={() => setOpen(false)}
         type={modalState.type === "post" ? "themePost" : "themePut"}

--- a/app/components/RequireAuth/RequireAuth.tsx
+++ b/app/components/RequireAuth/RequireAuth.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React, { ReactNode, useEffect } from "react";
+import Header from "@/components/common/Header/Header";
+import { useGetThemeList } from "@/queries/getThemeList";
+import { useCurrentTheme } from "@/components/atoms/currentTheme.atom";
+import { useRouter } from "next/navigation";
+import * as S from "@/home/HomeView.styled";
+import { useIsLoggedInValue } from "@/components/atoms/account.atom";
+import MainDrawer from "@/components/common/Drawer/Drawer";
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+function RequireAuth({
+  children,
+}: RequireAuthProps): React.ReactElement | null {
+  const isLoggedIn = useIsLoggedInValue();
+  const [currentTheme, setCurrentTheme] = useCurrentTheme();
+  const router = useRouter();
+
+  const { data: categories = [] } = useGetThemeList();
+  const props = { categories };
+
+  useEffect(() => {
+    if (categories.length > 0) {
+      setCurrentTheme(
+        categories.map((obj) => ({
+          id: obj.id,
+          title: obj.title,
+        }))
+      );
+    }
+  }, [categories, setCurrentTheme]);
+
+  useEffect(() => {
+    if (isLoggedIn && currentTheme.length > 0) {
+      router.push(
+        `/home?title=${encodeURIComponent(
+          currentTheme[currentTheme.length - 1].title
+        )}`
+      );
+    }
+  }, [isLoggedIn, currentTheme, router]);
+
+  if (isLoggedIn) {
+    return (
+      <S.Wrapper>
+        <MainDrawer {...props} />
+        <S.Cont component="main">
+          <Header />
+          {children}
+        </S.Cont>
+      </S.Wrapper>
+    );
+  }
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
+}
+
+export default RequireAuth;

--- a/app/components/ThemeDetail/ThemeDetailView.tsx
+++ b/app/components/ThemeDetail/ThemeDetailView.tsx
@@ -8,7 +8,9 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
+import { useRouter } from "next/navigation";
 import HintList from "../HintList/HintList";
+
 import * as S from "./ThemeDetail.styled";
 
 type Props = {
@@ -21,12 +23,13 @@ function ThemeDetailView(props: Props) {
   const selectedTheme = useSelectedThemeValue();
   const setModalState = useModalStateWrite();
   const activeHint = useActiveHintStateValue();
-
+  const router = useRouter();
   const [menuState, setMenuState] = useState(false);
   const toggleOnModalState = () => {
     if (activeHint.isOpen) {
       handleDialogOpen();
     } else {
+      router.push("/theme");
       setModalState({ isOpen: true, type: "put" });
     }
   };

--- a/app/components/atoms/currentTheme.atom.ts
+++ b/app/components/atoms/currentTheme.atom.ts
@@ -1,0 +1,20 @@
+import {
+  atom,
+  useRecoilValue,
+  useRecoilState,
+  useSetRecoilState,
+} from "recoil";
+
+interface ThemeInfo {
+  id: number;
+  title: string;
+}
+
+const currentThemeState = atom<ThemeInfo[]>({
+  key: "currentTheme",
+  default: [],
+});
+
+export const useCurrentTheme = () => useRecoilState(currentThemeState);
+export const useCurrentThemeValue = () => useRecoilValue(currentThemeState);
+export const useCurrentThemeWrite = () => useSetRecoilState(currentThemeState);

--- a/app/components/common/DeleteDialog/DeleteDialog.tsx
+++ b/app/components/common/DeleteDialog/DeleteDialog.tsx
@@ -1,5 +1,7 @@
+import { useRouter } from "next/navigation";
 import { useDeleteTheme } from "@/mutations/deleteTheme";
 import { useDeleteHint } from "@/mutations/deleteHint";
+import { useCurrentTheme } from "@/components/atoms/currentTheme.atom";
 import DeleteDialogView from "./DeleteDialogView";
 
 type ContentType = "hintDelete" | "themeDelete";
@@ -12,13 +14,23 @@ interface Props {
 }
 
 function DeleteDialog(props: Props) {
+  const router = useRouter();
+
   const { open, handleDialogClose, id, type } = props;
   const { mutateAsync: deleteTheme } = useDeleteTheme();
   const { mutateAsync: deleteHint } = useDeleteHint();
+  const [currentTheme, setCurrentTheme] = useCurrentTheme();
 
   const handleThemeDelete = () => {
+    const filteredArray = currentTheme.filter((obj) => obj.id !== id);
+    setCurrentTheme(filteredArray);
     deleteTheme({ id });
     handleDialogClose();
+    router.push(
+      `/home?title=${encodeURIComponent(
+        filteredArray[filteredArray.length - 1].title
+      )}`
+    );
   };
 
   const handleHintDelete = () => {

--- a/app/components/common/Dialog/Dialog.tsx
+++ b/app/components/common/Dialog/Dialog.tsx
@@ -12,9 +12,8 @@ interface Props {
 function Dialog(props: Props) {
   const { open, handleDialogClose, type, handleBtn } = props;
 
-  const handleCancleDialog = () => {
+  const handleQuitDialog = () => {
     handleBtn();
-
     handleDialogClose();
   };
 
@@ -42,7 +41,7 @@ function Dialog(props: Props) {
   const DialogProps = {
     open,
     handleDialogClose,
-    handleCancleDialog,
+    handleQuitDialog,
     content: { ...content[type] },
   };
 

--- a/app/components/common/Dialog/DialogView.tsx
+++ b/app/components/common/Dialog/DialogView.tsx
@@ -11,16 +11,16 @@ import React from "react";
 interface Props {
   open: boolean;
   handleDialogClose: () => void;
-  content:any;
-  handleCancleDialog: () => void;
+  content: any;
+  handleQuitDialog: () => void;
 }
 
 const CANCEL = "취소";
-const STAY = "그만두기";
+const QUIT = "그만두기";
 
 function DeleteThemeDialogView(props: Props) {
-  const { open, handleDialogClose, content, handleCancleDialog } = props;
-  
+  const { open, handleDialogClose, content, handleQuitDialog } = props;
+
   return (
     <Dialog
       open={open}
@@ -29,17 +29,17 @@ function DeleteThemeDialogView(props: Props) {
       aria-describedby="alert-dialog-description"
     >
       <DialogTitle style={{ color: "white" }} id="alert-dialog-title">
-      {content.title}
+        {content.title}
       </DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">
-        {content.description}
+          {content.description}
         </DialogContentText>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleDialogClose}>{CANCEL}</Button>
-        <Button onClick={handleCancleDialog} autoFocus>
-          {STAY}
+        <Button onClick={handleQuitDialog} autoFocus>
+          {QUIT}
         </Button>
       </DialogActions>
     </Dialog>

--- a/app/home/Home.tsx
+++ b/app/home/Home.tsx
@@ -4,8 +4,6 @@ import React, { useEffect, useState } from "react";
 import { useGetThemeList } from "@/queries/getThemeList";
 import useCheckSignIn from "@/hooks/useCheckSignIn";
 import { useRouter } from "next/navigation";
-import { useModalState } from "@/components/atoms/modals.atom";
-import Dialog from "@/components/common/Dialog/Dialog";
 import { useSnackBarInfo } from "@/components/atoms/snackBar.atom";
 import SnackBar from "@/components/SnackBar/SnackBar";
 import Loader from "@/components/Loader/Loader";
@@ -16,8 +14,6 @@ function Home() {
   const router = useRouter();
   const [open, setOpen] = useState<boolean>(false);
   const [snackInfo, setSnackBarInfo] = useSnackBarInfo();
-
-  const [modalState, setModalState] = useModalState();
 
   const handleDialog = () => {
     setOpen(!open);
@@ -49,12 +45,6 @@ function Home() {
   return (
     <>
       <HomeView {...themeAllProps} />
-      <Dialog
-        open={open}
-        handleBtn={() => setModalState({ ...modalState, isOpen: false })}
-        handleDialogClose={() => setOpen(false)}
-        type={modalState.type === "post" ? "themePost" : "themePut"}
-      />
       <SnackBar
         open={snackInfo.isOpen}
         ment={snackInfo.message}

--- a/app/home/HomeView.tsx
+++ b/app/home/HomeView.tsx
@@ -1,42 +1,21 @@
 import React from "react";
-import MainDrawer from "@/components/common/Drawer/Drawer";
-import MakeThemePage from "@/components/MakeThemePage/MakeThemePage";
 import EmptyHome from "@/components/common/EmptyHome/EmptyHome";
 import HintList from "@/components/ThemeDetail/ThemeDetail";
-import Header from "@/components/common/Header/Header";
 
 import { Themes } from "@/queries/getThemeList";
-import { useModalStateValue } from "@/components/atoms/modals.atom";
 
-import * as S from "./HomeView.styled";
 
 type Props = {
   categories: Themes;
-  handleDialog: ()=>void;
 };
 
 function HomeView(props: Props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { categories } = props;
-  const modalState = useModalStateValue();
-  let content;
 
-  if (!categories) {
-    content = <EmptyHome />;
-  } else if (!modalState.isOpen) {
-    content = <HintList />;
-  } else {
-    content = <MakeThemePage/>;
+  if (categories.length < 1) {
+    return <EmptyHome />;
   }
-
-  return (
-    <S.Wrapper>
-      <MainDrawer {...props} />
-      <S.Cont component="main">
-        <Header />
-        {content}
-      </S.Cont>
-    </S.Wrapper>
-  );
+  return <HintList />;
 }
 export default HomeView;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import StyledJsxRegistry from "@/lib/registry";
 import Recoil from "@/lib/recoil";
 import ReactQueryProvider from "@/lib/reactQueryProvider";
-import MuiProvider from "./lib/muiProvider";
-import StyledProvider from "./lib/themeProvider";
+import MuiProvider from "@/lib/muiProvider";
+import StyledProvider from "@/lib/themeProvider";
+import RequireAuth from "@/components/RequireAuth/RequireAuth";
 
 export const metadata = {
   title: "NEXT ROOM",
@@ -21,7 +22,9 @@ export default function RootLayout({
           <ReactQueryProvider>
             <StyledProvider>
               <StyledJsxRegistry>
-                <MuiProvider>{children}</MuiProvider>
+                <MuiProvider>
+                  <RequireAuth>{children}</RequireAuth>
+                </MuiProvider>
               </StyledJsxRegistry>
             </StyledProvider>
           </ReactQueryProvider>

--- a/app/login/Login.tsx
+++ b/app/login/Login.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { useRouter } from "next/navigation";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { ADMIN_CODE, ADMIN_PASSWORD } from "@/consts/components/login";
@@ -18,7 +17,6 @@ interface FormValues {
 }
 
 function Login() {
-  const router = useRouter();
   const isLoggedIn = useIsLoggedInValue();
   const {
     mutateAsync: postLogin,
@@ -103,7 +101,6 @@ function Login() {
   };
 
   if (isLoggedIn) {
-    router.push("/home");
     return <Loader />;
   }
 

--- a/app/theme/page.tsx
+++ b/app/theme/page.tsx
@@ -1,0 +1,5 @@
+import MakeThemePage from "@/components/MakeThemePage/MakeThemePage";
+
+export default function ThemePage() {
+  return <MakeThemePage />;
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 로그인 유뮤로 레이아웃을 분리했어요
  로그인 시 헤더/메뉴바 레이아웃을 공통레이아웃으로 분리했어요
- url pathname을 선택된 테마로 설정했어요 ex. /home?title=타이틀네임
- makeThemePage를 페이지로 분리했어요 /theme

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- RequireAuth 공통 레이아웃 파일을 추가했어요
- Login 라우터 코드를 제거했어요

<br><br>

### 💡 필요한 후속작업이 있어요.

- modalState를 제거할 예정입니다

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
